### PR TITLE
Update test app cast

### DIFF
--- a/app_cast/testappcast.xml
+++ b/app_cast/testappcast.xml
@@ -1,38 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
     <channel>
-        <title>For unit test only</title>
+        <title>Debt Now App - Appcast</title>
         <item>
-            <title>Version 1.8.6</title>
-            <description>desc Версия</description>
-            <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
-            <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="2.0" />
-            <sparkle:tags>
-                <sparkle:criticalUpdate />
-            </sparkle:tags>
-        </item>
-        <!-- The best chosen release -->
-        <item>
-            <title>Version 1.8.6</title>
-            <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="3.0" sparkle:os="android" />
-            <sparkle:deltas>
-                <enclosure url="http://localhost:1337/3.0_from_2.0.patch" sparkle:version="3.0" sparkle:deltaFrom="7.0" length="1235" type="application/octet-stream" sparkle:edSignature="..." />
-
-                <enclosure url="http://localhost:1337/3.0_from_1.0.patch" sparkle:version="3.0" sparkle:deltaFrom="7.0" length="1485" type="application/octet-stream" sparkle:edSignature="..." />
-            </sparkle:deltas>
-        </item>
-        <!-- A release testing minimumSystemVersion -->
-        <item>
-            <title>Version 1.8.6</title>
-            <pubDate>Sat, 26 Jul 2014 15:20:13 +0000</pubDate>
-            <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:version="4.0" sparkle:os="iOS" />
-            <sparkle:minimumSystemVersion>17.0.0</sparkle:minimumSystemVersion>
-        </item>
-        <!-- A joke release testing maximumSystemVersion -->
-        <item>
-            <title>Version 7.8.6</title>
-            <sparkle:version>7.8.6</sparkle:version>
-            <sparkle:maximumSystemVersion>7.8.7</sparkle:maximumSystemVersion>
+            <title>Version 2.0.0</title>
+            <description>Minor updates and improvements.</description>
+            <pubDate>Sun, 30 Dec 2018 12:00:00 +0000</pubDate>
+            <enclosure url="https://play.google.com/store/apps/details?id=com.moonwink.treasury" sparkle:version="2.0.0" sparkle:os="android" />
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Upgrader Alert don’t show ignore and later button. Because Our test app cast is old.
<p align="center">
  <img src="https://github.com/encointer/feed/assets/76556278/5cc6df71-f779-44de-b36e-001c16ae06ec" width="32%" />
  <img src="https://github.com/encointer/feed/assets/76556278/93c71c38-5505-464b-89a9-26a3c89e84b9" width="32%" />
</p>
